### PR TITLE
WordPress 6.8 compatibility: Add __next40pxDefaultSize to remaining controls to prevent deprecation notices

### DIFF
--- a/assets/js/components/access-table.js
+++ b/assets/js/components/access-table.js
@@ -77,6 +77,7 @@ function AccessTableRow( props ) {
 					readOnly
 					onClick=${ selectField }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize={ true }
 				/>
 			</td>
 			<td className="column-last-used">${ last_used || '—' }</td>

--- a/assets/js/components/api-key-form.js
+++ b/assets/js/components/api-key-form.js
@@ -24,6 +24,7 @@ function ApiKeyForm( { onSubmit } ) {
 					onChange=${ setName }
 					value=${ name }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize={ true }
 				/>
 			</${ FlexItem }>
 			<${ FlexItem }>

--- a/assets/js/components/package-selector.js
+++ b/assets/js/components/package-selector.js
@@ -81,6 +81,7 @@ function PackageSelector( props ) {
 					onChange=${ setSearchTerm }
 					value=${ searchTerm }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize={ true }
 				/>
 			<ul>${ listItems }</ul>
 		</div>`;

--- a/assets/js/components/release-actions.js
+++ b/assets/js/components/release-actions.js
@@ -39,6 +39,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-download-url-${ composerName }"
 								onClick=${ selectField }
+								__next40pxDefaultSize={ true }
 							/>
 						</td>
 					</tr>
@@ -52,6 +53,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-require-${ composerName }"
 								onClick=${ selectField }
+								__next40pxDefaultSize={ true }
 							/>
 							<span className="description">
 								<em>${ copyPasteHtml }</em>
@@ -68,6 +70,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-cli-${ composerName }"
 								onClick=${ selectField }
+								__next40pxDefaultSize={ true }
 							/>
 						</td>
 					</tr>


### PR DESCRIPTION
Fixes #11 