### PR TITLE
Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0.

### DIFF
--- a/assets/js/components/access-table.js
+++ b/assets/js/components/access-table.js
@@ -76,7 +76,7 @@ function AccessTableRow( props ) {
 					value=${ token }
 					readOnly
 					onClick=${ selectField }
-					__nextHasNoMarginBottom
+					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 			</td>

--- a/assets/js/components/api-key-form.js
+++ b/assets/js/components/api-key-form.js
@@ -23,7 +23,7 @@ function ApiKeyForm( { onSubmit } ) {
 					placeholder=${ __( 'Name', 'satispress' ) }
 					onChange=${ setName }
 					value=${ name }
-					__nextHasNoMarginBottom
+					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 			</${ FlexItem }>

--- a/assets/js/components/package-selector.js
+++ b/assets/js/components/package-selector.js
@@ -67,7 +67,7 @@ function PackageSelector( props ) {
 						checked=${ packageExists( slug, type ) }
 						onChange=${ checked => togglePackage( slug, type, checked ) }
 						label=${ name }
-						__nextHasNoMarginBottom
+						__nextHasNoMarginBottom={ true }
 					/>
 				</li>
 			`;
@@ -80,7 +80,7 @@ function PackageSelector( props ) {
 					placeholder=${ __( 'Search', 'satispress' ) + ' ' + tab.title }
 					onChange=${ setSearchTerm }
 					value=${ searchTerm }
-					__nextHasNoMarginBottom
+					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 			<ul>${ listItems }</ul>


### PR DESCRIPTION
Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.